### PR TITLE
[Task] ui 전체적 수정

### DIFF
--- a/PadoStudio/PadoStudio/Features/Camera/ImageComposer.swift
+++ b/PadoStudio/PadoStudio/Features/Camera/ImageComposer.swift
@@ -180,7 +180,8 @@ private extension ImageComposer {
         let imageScale = size.width / ScreenRatioUtility.imageWidth
         
         // CameraView와 동일한 캐릭터 크기 계산
-        let maxSize = min(180.scaled * imageScale, (size.width) / CGFloat(max(characterCount, 1)))
+        let baseCharacterSize: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 180 : 120
+        let maxSize = min(baseCharacterSize.scaled * imageScale, (size.width) / CGFloat(max(characterCount, 1)))
         let spacing = -maxSize * 0.4
         
         // CameraView와 동일한 bottomPadding 사용
@@ -216,7 +217,8 @@ private extension ImageComposer {
         let dateString = dateFormatter.string(from: Date())
         
         
-        let fontSize: CGFloat = 20 * (size.width / ScreenRatioUtility.imageWidth)
+        let baseFontSize: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 20 : 14
+        let fontSize: CGFloat = baseFontSize.scaled * (size.width / ScreenRatioUtility.imageWidth)
         
         
         let font = UIFont(name: "EliceDigitalBaeum-Bd", size: fontSize) ?? UIFont.systemFont(ofSize: fontSize, weight: .semibold)
@@ -233,7 +235,7 @@ private extension ImageComposer {
         let textSize = attributedString.size()
         
         // 우측 상단 위치 (여백)
-        let margin: CGFloat = ScreenRatioUtility.screenHeight < 812 ? (8 * ScreenRatioUtility.heightRatio) : (40 *  ScreenRatioUtility.heightRatio)
+        let margin: CGFloat = ScreenRatioUtility.screenHeight < 812 ? (8.scaled) : (40.scaled)
         
         let textRect = CGRect(
             x: size.width - textSize.width - margin,

--- a/PadoStudio/PadoStudio/Features/Character/CharacterViewer/CameraButtonView.swift
+++ b/PadoStudio/PadoStudio/Features/Character/CharacterViewer/CameraButtonView.swift
@@ -16,13 +16,13 @@ struct CameraButtonView: View {
                 Image(systemName: "camera.fill")
                     .resizable()
                     .scaledToFit()
-                    .frame(width: 48, height: 36)
+                    .frame(width: 48.scaled, height: 36.scaled)
                     .foregroundColor(.white)
                 Text("촬영하기")
-                    .font(.eliceBold(size: 30)) // 커스텀 폰트 적용!
+                    .font(.eliceBold(size: 30.scaled)) // 커스텀 폰트 적용!
                     .foregroundColor(.white)
             }
-            .frame(width: 200, height: 200)
+            .frame(width: 200.scaled, height: 200.scaled)
             .background(
                 Circle()
                     .foregroundColor(.primaryGreen))

--- a/PadoStudio/PadoStudio/Features/Character/CharacterViewer/CharacterCheckView.swift
+++ b/PadoStudio/PadoStudio/Features/Character/CharacterViewer/CharacterCheckView.swift
@@ -22,19 +22,19 @@ struct CharacterCheckView: View {
                     .resizable()
                     .ignoresSafeArea()
 
-                VStack(spacing: 0) {
+                VStack(spacing: 0.scaled) {
                     // 중앙에 오게 하기 위한 Spacer
                     ToolbarView(title: "캐릭터 확인", titleColor: .white)
                         .safeAreaInset(edge: .top) {
-                            Color.clear.frame(height: 48)
+                            Color.clear.frame(height: 48.scaled)
                         }
 
                     Spacer()
 
                     // 캐릭터와 텍스트 묶음
-                    VStack(spacing: 2) {
+                    VStack(spacing: 2.scaled) {
 
-                        Spacer().frame(height: 160)  // SurferCharacterView 위에 여백
+                        Spacer().frame(height: 160.scaled)  // SurferCharacterView 위에 여백
                         if viewModel.characterImages.count > 6 {
                             ScrollView(.horizontal) {
                                 SurferCharacterView(proxy: proxy)

--- a/PadoStudio/PadoStudio/Features/Character/CharacterViewer/CharacterTextView.swift
+++ b/PadoStudio/PadoStudio/Features/Character/CharacterViewer/CharacterTextView.swift
@@ -11,14 +11,14 @@ struct CharacterTextView: View {
     let proxy: GeometryProxy
 
     var body: some View {
-            HStack(alignment: .firstTextBaseline, spacing: 2) {  // 👈 베이스라인 정렬!
+        HStack(alignment: .firstTextBaseline, spacing: 2.scaled) {  // 👈 베이스라인 정렬!
                 Text("완성된 캐릭터")
                     .font(.title2BoldResponsive(proxy))
                 Text("를 확인해주세요!")
-                    .font(.title3RegularResponsive(size: 20, proxy: proxy))
+                .font(.title3RegularResponsive(size: 20.scaled, proxy: proxy))
             }
             .frame(maxWidth: .infinity, alignment: .center)
-            .frame(height: 60)
+            .frame(height: 60.scaled)
 
     }
 }

--- a/PadoStudio/PadoStudio/Features/Character/Creation/presentation/CharacterCreateView.swift
+++ b/PadoStudio/PadoStudio/Features/Character/Creation/presentation/CharacterCreateView.swift
@@ -47,7 +47,7 @@ struct CharacterCreateView: View {
                 showBackAlert = true
             }
                     .safeAreaInset(edge: .top) {
-                        Color.clear.frame(height: 48)
+                        Color.clear.frame(height: 48.scaled)
                     }
 
             CharacterPreviewPager(
@@ -119,13 +119,13 @@ struct ActionButtonPanel: View {
     @EnvironmentObject var navModel: NavigationViewModel
 
     var body: some View {
-        HStack(spacing: 12) {
+        HStack(spacing: 12.scaled) {
             resetButton
             Spacer()
             primaryActionButton
         }
         .frame(maxWidth: .infinity)
-        .padding(.top, 8)
+        .padding(.top, 8.scaled)
     }
 
     private var resetButton: some View {

--- a/PadoStudio/PadoStudio/Features/Character/Creation/presentation/component/CharacterPreviewPager.swift
+++ b/PadoStudio/PadoStudio/Features/Character/Creation/presentation/component/CharacterPreviewPager.swift
@@ -30,29 +30,29 @@ struct CharacterPreviewPager: View {
 
                 rightArrowButton
             }
-            .padding(.horizontal, 24)
+            .padding(.horizontal, 24.scaled)
 
-            HStack(spacing: 8) {
+            HStack(spacing: 8.scaled) {
                 ForEach(0..<number, id: \.self) { index in
                     Circle()
                         .fill(
                             index == currentIndex
                                 ? Color.primaryGreen : Color.gray05
                         )
-                        .frame(width: 8, height: 8)
+                        .frame(width: 8.scaled, height: 8.scaled)
                 }
             }
-            .padding(.top, 8)
+            .padding(.top, 8.scaled)
         }
         .frame(maxWidth: .infinity)
-        .padding(.bottom, 24)
+        .padding(.bottom, 24.scaled)
     }
 
     private var leftArrowButton: some View {
         Button(action: viewModel.prevPage) {
             Image(systemName: "chevron.left")
                 .foregroundColor(.white)
-                .font(.system(size: 24, weight: .bold))
+                .font(.system(size: 24.scaled, weight: .bold))
                 .padding()
         }
         .opacity(currentIndex > 0 ? 1 : 0)
@@ -62,7 +62,7 @@ struct CharacterPreviewPager: View {
         Button(action: { viewModel.nextPage(count: number) }) {
             Image(systemName: "chevron.right")
                 .foregroundColor(.white)
-                .font(.system(size: 24, weight: .bold))
+                .font(.system(size: 24.scaled, weight: .bold))
                 .padding()
         }
         .opacity(currentIndex < number - 1 ? 1 : 0)

--- a/PadoStudio/PadoStudio/Features/Character/FrameSelection/CharacterFrameSelectionView.swift
+++ b/PadoStudio/PadoStudio/Features/Character/FrameSelection/CharacterFrameSelectionView.swift
@@ -51,7 +51,7 @@ struct CharacterFrameSelectionBody: View {
                     // 네비게이션바
                     ToolbarView(title: "프레임 고르기", titleColor: .black)
                         .safeAreaInset(edge: .top) {
-                            Color.clear.frame(height: 48)
+                            Color.clear.frame(height: 48.scaled)
                         }
 
                     Spacer()

--- a/PadoStudio/PadoStudio/Features/Character/FrameSelection/component/CharacterRowView.swift
+++ b/PadoStudio/PadoStudio/Features/Character/FrameSelection/component/CharacterRowView.swift
@@ -45,10 +45,10 @@ struct CharacterRowView: View {
         UIImage(named: "origin-standard") ?? UIImage()
     ]
 
-    VStack(spacing: 20) {
+    VStack(spacing: 20.scaled) {
         // 단독 미리보기
         CharacterRowView(characterImages: dummyImages)
-            .frame(width: 300)
+            .frame(width: 300.scaled)
             .background(Color.gray.opacity(0.1))
     }
     .padding()

--- a/PadoStudio/PadoStudio/Features/FramedImage/FramedImageView.swift
+++ b/PadoStudio/PadoStudio/Features/FramedImage/FramedImageView.swift
@@ -13,8 +13,12 @@ struct FramedImageView: View {
     var body: some View {
         Image(uiImage: identifiableImage.image)
             .resizable()
-            .scaledToFit()
-            .frame(width: ScreenRatioUtility.previewWidth)
+            .aspectRatio(contentMode: .fit)
+            .frame(
+                width: ScreenRatioUtility.imageWidth,
+                height: ScreenRatioUtility.imageHeight
+            )
+            .clipped()
     }
 }
 

--- a/PadoStudio/PadoStudio/Features/FramedImage/ImageCheckView.swift
+++ b/PadoStudio/PadoStudio/Features/FramedImage/ImageCheckView.swift
@@ -21,7 +21,7 @@ struct ImageCheckView: View {
 
                     HomeButtonView(proxy: proxy)
                         .safeAreaInset(edge: .top) {
-                            Color.clear.frame(height: 48)
+                            Color.clear.frame(height: 48.scaled)
                         }
 
                     Spacer()

--- a/PadoStudio/PadoStudio/Features/Gallery/Detail/PhotoDetailView.swift
+++ b/PadoStudio/PadoStudio/Features/Gallery/Detail/PhotoDetailView.swift
@@ -41,7 +41,12 @@ struct PhotoDetailView: View {
                         Image(uiImage: uiImage)
                             .resizable()
                             .aspectRatio(contentMode: .fit)
-                            .padding(.horizontal, 24)
+                            .frame(
+                                width: ScreenRatioUtility.imageWidth,
+                                height: ScreenRatioUtility.imageHeight
+                            )
+                            .cornerRadius(16.scaled)
+                            .clipped()
                             .padding(.bottom, 30)
                     } else {
                         Text("이미지를 불러올 수 없습니다.")

--- a/PadoStudio/PadoStudio/Features/Gallery/EmptyGalleryView.swift
+++ b/PadoStudio/PadoStudio/Features/Gallery/EmptyGalleryView.swift
@@ -14,7 +14,7 @@ struct EmptyGalleryView: View {
             Text("저장된 사진이 없습니다 :(")
                 .font(.title2Bold)
             Text("파도 사진관에서 오늘의 추억을 남겨보세요!")
-                .font(.styledRegular(size: 20))
+                .font(.styledRegular(size: 20.scaled))
         }
     }
 }

--- a/PadoStudio/PadoStudio/Features/Gallery/GalleryToolbar.swift
+++ b/PadoStudio/PadoStudio/Features/Gallery/GalleryToolbar.swift
@@ -31,8 +31,8 @@ struct GalleryToolbar: View {
             Spacer()
 
         }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 18)
+        .padding(.horizontal, 20.scaled)
+        .padding(.vertical, 18.scaled)
         .padding(.trailing, 50.scaled)
         .background(Color.white)
         .toolbar(.hidden, for: .navigationBar)

--- a/PadoStudio/PadoStudio/Features/Gallery/GalleryView.swift
+++ b/PadoStudio/PadoStudio/Features/Gallery/GalleryView.swift
@@ -13,12 +13,10 @@ struct GalleryView: View {
     @Environment(\.dismiss) var dismiss
     @State private var reloadTrigger = false
 
-    let columns = [
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-    ]
+    private var columns: [GridItem] {
+           let columnCount = UIDevice.current.userInterfaceIdiom == .pad ? 4 : 3
+           return Array(repeating: GridItem(.flexible(), spacing: 8.scaled), count: columnCount)
+       }
 
     var body: some View {
         VStack {

--- a/PadoStudio/PadoStudio/Features/Gallery/PhotoView.swift
+++ b/PadoStudio/PadoStudio/Features/Gallery/PhotoView.swift
@@ -12,6 +12,18 @@ import SwiftUI
 struct PhotoView: View {
     let imageModel: GalleryData
     @Binding var reloadTrigger: Bool
+    
+    
+    private var imageSize: CGSize {
+            let columnCount: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 4 : 3
+            let spacing: CGFloat = 8.scaled * (columnCount - 1)
+            let padding: CGFloat = 28.scaled // 좌우 패딩
+            let availableWidth = ScreenRatioUtility.screenWidth - spacing - padding
+            let width = availableWidth / columnCount
+            let height = width * 4/3 // 4:3 비율 유지
+            return CGSize(width: width, height: height)
+        }
+    
 
     var body: some View {
         VStack {
@@ -23,7 +35,7 @@ struct PhotoView: View {
                     Image(uiImage: uiImage)
                         .resizable()
                         .aspectRatio(contentMode: .fill)
-                        .frame(width: 120, height: 160)
+                        .frame(width: imageSize.width, height: imageSize.height)
                         .clipped()
                         .cornerRadius(8)
                         .shadow(radius: 2)
@@ -33,13 +45,13 @@ struct PhotoView: View {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .resizable()
                         .scaledToFit()
-                        .frame(width: 40, height: 40)
+                        .frame(width: 40.scaled, height: 40.scaled)
                         .foregroundColor(.primaryGreen)
                     Text("이미지 없음")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
-                .frame(width: 120, height: 160)
+                .frame(width: imageSize.width, height: imageSize.height)
                 .background(Color.gray.opacity(0.1))
                 .cornerRadius(8)
                 .shadow(radius: 2)


### PR DESCRIPTION
## 관련 이슈
- Closes #117 

## 작업 내용
-프레임에서 날짜와 캐릭터 크기 아이패드와 아이폰용 나눠서 새로 크기 맞췄습니다. 
- 갤러리뷰에서 사진이 겹쳐보이는 현상이 발생해서 아이폰에서는 한 줄에 3개 들어가게 바꿨습니다. 
- 공유뷰와 카메라 뷰에서의 사진 크기 통일시켰습니다.


## 스크린샷 (UI 변경 시)
- Before/After 스크린샷

## 체크리스트
- [ ] 빌드 에러 없음
- [ ] 기본 동작 테스트 완료
- [ ] 코드 리뷰 준비 완료
